### PR TITLE
Add Recheck Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -367,6 +367,3 @@ MigrationBackup/
 FodyWeavers.xsd
 
 **/[Bb]uild/
-
-# Ignore project files locally — tracked files will remain in the repo but local edits can be marked assume-unchanged
-*.csproj

--- a/.gitignore
+++ b/.gitignore
@@ -367,3 +367,6 @@ MigrationBackup/
 FodyWeavers.xsd
 
 **/[Bb]uild/
+
+# Ignore project files locally — tracked files will remain in the repo but local edits can be marked assume-unchanged
+*.csproj

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -47,6 +47,12 @@
               IgnoreExitCode="true"
               Condition="Exists('$(MSBuildThisFileDirectory)Build\SPT\user')" />
 
+        <!-- Copy run-recheck.bat into repo Build folder if it exists (keep with other deploy steps) -->
+        <Exec Command="xcopy &quot;$(MSBuildThisFileDirectory)run-recheck.ps1&quot; &quot;$(MSBuildThisFileDirectory)Build\&quot; /Y /Q"
+              ContinueOnError="true"
+              IgnoreExitCode="true"
+              Condition="Exists('$(MSBuildThisFileDirectory)run-recheck.ps1')" />
+
         <Message Importance="high" Text="Deployment to test locations complete!" />
     </Target>
 </Project>

--- a/NarcoNet.Server/Services/SyncService.cs
+++ b/NarcoNet.Server/Services/SyncService.cs
@@ -449,4 +449,67 @@ public class SyncService
         double elapsed = (DateTime.UtcNow - startTime).TotalMilliseconds;
         _logger.LogInformation("Change detection completed in {Elapsed:F0}ms", elapsed);
     }
+
+    /// <summary>
+    ///     Perform an on-demand recheck of the configured sync paths, comparing
+    ///     current filesystem state to the last saved snapshot. This is similar
+    ///     to the startup detection logic but intended to be called at runtime
+    ///     (e.g. from an HTTP endpoint) and returns the detected changes.
+    /// </summary>
+    public async Task<List<FileChangeEntry>> RecheckAsync(
+        List<SyncPath> syncPaths,
+        NarcoNetConfig config,
+        CancellationToken cancellationToken = default)
+    {
+        DateTime startTime = DateTime.UtcNow;
+
+        // Load existing changelog and snapshot
+        FileChangeLog changeLog = await _changeLogService.LoadChangeLogAsync(cancellationToken);
+        FileSystemSnapshot? lastSnapshot = await _changeLogService.LoadSnapshotAsync(cancellationToken);
+
+        // Build current snapshot (without hashes initially for speed)
+        FileSystemSnapshot currentSnapshot = await BuildSnapshotAsync(
+            syncPaths,
+            config,
+            changeLog.CurrentSequence,
+            cancellationToken);
+
+        // Detect changes between snapshots
+        List<FileChangeEntry> changes = await DetectChangesAsync(
+            lastSnapshot,
+            currentSnapshot,
+            changeLog.CurrentSequence,
+            cancellationToken);
+
+        if (changes.Count > 0)
+        {
+            // Append changes to changelog
+            await _changeLogService.AppendChangesAsync(changes, cancellationToken);
+
+            // Update snapshot with hashes for changed files
+            foreach (var change in changes.Where(c => c.Operation != ChangeOperation.Delete))
+            {
+                if (currentSnapshot.Files.TryGetValue(change.FilePath, out FileMetadata? metadata))
+                {
+                    currentSnapshot.Files[change.FilePath] = metadata with { Hash = change.Hash };
+                }
+            }
+        }
+
+        // Save updated snapshot
+        FileSystemSnapshot updatedSnapshot = currentSnapshot with
+        {
+            SequenceNumber = changeLog.CurrentSequence + changes.Count,
+            Timestamp = DateTime.UtcNow
+        };
+        await _changeLogService.SaveSnapshotAsync(updatedSnapshot, cancellationToken);
+
+        // Prune old changelog entries
+        await _changeLogService.PruneOldEntriesAsync(30, cancellationToken);
+
+        double elapsed = (DateTime.UtcNow - startTime).TotalMilliseconds;
+        _logger.LogInformation("Recheck completed in {Elapsed:F0}ms (detected {Count} changes)", elapsed, changes.Count);
+
+        return changes;
+    }
 }

--- a/NarcoNet.Server/Services/SyncService.cs
+++ b/NarcoNet.Server/Services/SyncService.cs
@@ -454,7 +454,7 @@ public class SyncService
     ///     Perform an on-demand recheck of the configured sync paths, comparing
     ///     current filesystem state to the last saved snapshot. This is similar
     ///     to the startup detection logic but intended to be called at runtime
-    ///     (e.g. from an HTTP endpoint) and returns the detected changes.
+    ///     (e.g. from an HTTPS endpoint) and returns the detected changes.
     /// </summary>
     public async Task<List<FileChangeEntry>> RecheckAsync(
         List<SyncPath> syncPaths,

--- a/run-recheck.ps1
+++ b/run-recheck.ps1
@@ -1,0 +1,45 @@
+# NarcoNet Server Endpoint Test Script
+# Run this after starting the SPT server
+
+$baseUrl = 'https://localhost:6969'
+$endpoint = "$($baseUrl.TrimEnd('/'))/narconet/recheck"
+
+Write-Host "Invoking recheck endpoint: $endpoint" -ForegroundColor Cyan
+
+# Bypass SSL certificate validation for self-signed certs
+add-type @"
+    using System.Net;
+    using System.Security.Cryptography.X509Certificates;
+    public class TrustAllCertsPolicy : ICertificatePolicy {
+        public bool CheckValidationResult(
+            ServicePoint srvPoint, X509Certificate certificate,
+            System.Net.WebRequest request, int certificateProblem) {
+            return true;
+        }
+    }
+"@
+[System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+
+$exitCode = 0
+try {
+    $response = Invoke-RestMethod -Uri $endpoint -Method Post -TimeoutSec 120 -Headers @{ 'Accept' = 'application/json' }
+    Write-Host "Response:" -ForegroundColor Green
+    $response | ConvertTo-Json -Depth 10 | Write-Host
+    $exitCode = 0
+}
+catch {
+    Write-Host "Request failed:" -ForegroundColor Red
+    Write-Host $_.Exception.Message -ForegroundColor Red
+    $exitCode = 1
+}
+
+# Pause so a double-clicked window doesn't close immediately
+Write-Host "`nPress Enter to exit..." -ForegroundColor DarkCyan
+try {
+    Read-Host | Out-Null
+} catch {
+    # In non-interactive contexts Read-Host can fail; ignore
+}
+
+exit $exitCode


### PR DESCRIPTION
Allows a server owner (I am using a vps) to add client mods on the fly and trigger a recheck of the changed files so that I don't have to restart the server everytime I make client mod changes.

The clients would need to restart in order to pick up those changes (the original by Corter had a button in the F12 menu to trigger a sync, could potentially hook that up then a client could sync on the fly)

The server admin can use the .ps1 file to run the recheck on demand.

Not sure if you want this, just wanted to submit a PR and if you like it great, if not, no worries!

There is some duplicate code with this, but I didn't want to refactor a bunch initially.